### PR TITLE
Strengthen wind threshold (25→35 km/h) & increase cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wreck Beach Wind Alert System
 
-Automated wind monitoring system for Wreck Beach, Vancouver, BC. Sends SMS alerts when north-westerly winds exceed 25 km/h.
+Automated wind monitoring system for Wreck Beach, Vancouver, BC. Sends SMS alerts when north-westerly winds exceed 35 km/h.
 
 ## Features
 - Monitors wind conditions every 60 minutes
@@ -69,7 +69,7 @@ The system is designed to run on GitHub Actions (free tier). See `.github/workfl
 ## Wind Criteria
 
 - **Direction**: North-westerly (292.5° to 337.5°)
-- **Speed**: ≥ 25 km/h
+- **Speed**: ≥ 35 km/h
 - **Location**: Wreck Beach (49.2611°N, 123.2614°W)
 
 ## Cost Estimate

--- a/src/conditions.py
+++ b/src/conditions.py
@@ -14,7 +14,7 @@ def is_northwest(degrees: float) -> bool:
 
 def is_good_wind_direction(degrees: float) -> bool:
     """
-    Check if wind direction is good for windsurfing/kitesurfing at Wreck Beach.
+    Check if wind direction is good for surfing at Wreck Beach.
     Good directions: North (N), Northwest (NW), and West (W) with some flexibility.
 
     Using wider ranges for better coverage:

--- a/src/config.py
+++ b/src/config.py
@@ -23,8 +23,8 @@ COORDINATES = {
 STATE_FILE_PATH = os.getenv('STATE_FILE_PATH', '/tmp/wind_alert_state.json')
 
 # Alert Configuration
-ALERT_COOLDOWN_HOURS = int(os.getenv('ALERT_COOLDOWN_HOURS', '6'))
-WIND_SPEED_THRESHOLD_KMH = float(os.getenv('WIND_SPEED_THRESHOLD_KMH', '25.0'))
+ALERT_COOLDOWN_HOURS = int(os.getenv('ALERT_COOLDOWN_HOURS', '8'))
+WIND_SPEED_THRESHOLD_KMH = float(os.getenv('WIND_SPEED_THRESHOLD_KMH', '35.0'))
 DAILY_ALERT_LIMIT = int(os.getenv('DAILY_ALERT_LIMIT', '4'))
 
 # Application Settings


### PR DESCRIPTION
## Changes
- **Wind speed threshold:** 25 → 35 km/h (reduces false alerts — need real wind swell, not light gusts)
- **Alert cooldown:** 6 → 8 hours (fewer texts per day)
- **Fix:** Updated comment referencing kitesurfing → surfing
- **README:** Updated to reflect new 35 km/h threshold

These values are still configurable via env vars (`WIND_SPEED_THRESHOLD_KMH`, `ALERT_COOLDOWN_HOURS`).